### PR TITLE
feat(setup-node): add `npm-version` input

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -1,12 +1,16 @@
 name: setup-node
+description: 'Sets up node and npm for Angular development'
 
 inputs:
-  node-version: 
+  node-version:
     description: 'Node Versions'
     required: true
+  npm-version:
+    description: 'The version of npm to install'
+    default: 'latest'
   use-stamp-cache:
     description: 'Whether or not to use the stamp cache (skip install, use old node_modules)'
-    default: false
+    default: 'false'
   registry-url:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
   working-directory:
@@ -23,13 +27,18 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
+    - run: npx npm -g i npm@${{ inputs.npm-version }}
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      name: Upgrade npm
+
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash
       env:
         STAMP: ${{ inputs.use-stamp-cache }}
-      run: |        
-        if [ "$STAMP" == "true" ] 
+      run: |
+        if [ "$STAMP" == "true" ]
         then
           echo "dir=${{ inputs.working-directory }}/node_modules" >> ${GITHUB_OUTPUT}
         else
@@ -39,13 +48,13 @@ runs:
     - name: Get cache keys
       id: npm-cache-keys
       shell: bash
-      env: 
+      env:
         NODE_VERSION: ${{ inputs.node-version }}
         PACKAGE_HASH: ${{ hashFiles('**/package-lock.json') }}
         OS: ${{ runner.os }}
         STAMP: ${{ inputs.use-stamp-cache }}
       run: |
-        if [ "$STAMP" == "true" ] 
+        if [ "$STAMP" == "true" ]
         then
           echo "key=npm-stamp-$OS-$NODE_VERSION-$PACKAGE_HASH" >> ${GITHUB_OUTPUT}
           echo "restore=npm-stamp-$OS-$NODE_VERSION-" >> ${GITHUB_OUTPUT}
@@ -68,7 +77,7 @@ runs:
       name: Install Dependencies
       if: inputs.use-stamp-cache && steps.npm-cache.outputs.cache-hit != 'true'
 
-    - run: |  
+    - run: |
         rm -rf node_modules/.ng-packagr-ngcc
         rm -rf node_modules/.cli-ngcc
         rm -rf node_modules/.cache


### PR DESCRIPTION
Allows the user to specify a version of npm to which to upgrade. By default it upgrades to the latest.