### PR TITLE
fix(setup-node): cannot install npm into system folder

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -16,7 +16,7 @@ inputs:
   working-directory:
     description: 'The working directory of setup'
     default: '.'
-  install: 
+  install:
     description: 'Whether or not to run npm ci'
     default: 'true'
 
@@ -32,7 +32,11 @@ runs:
         package-manager-cache: false
 
     - run: |
-        npx npm -g i npm@${{ inputs.npm-version }}
+        npx npm config set prefix "${HOME}/.npm-global"
+        npx npm install -g npm@${{ inputs.npm-version }}
+        echo "${HOME}/.npm-global/bin" >> $GITHUB_PATH
+        echo "npm_version=$(${HOME}/.npm-global/bin/npm -v)" >> ${GITHUB_OUTPUT}
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       if: inputs.npm-version != ''
 

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -35,14 +35,14 @@ runs:
         npx npm config set prefix "${HOME}/.npm-global"
         npx npm install -g npm@${{ inputs.npm-version }}
         echo "${HOME}/.npm-global/bin" >> $GITHUB_PATH
-        echo "npm_version=$(${HOME}/.npm-global/bin/npm -v)" >> ${GITHUB_OUTPUT}
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       if: inputs.npm-version != ''
+      name: Upgrade npm
 
     - run: echo "npm_version=$(npm -v)" >> ${GITHUB_OUTPUT}
       shell: bash
-      name: Upgrade npm
+      name: Get npm version
       id: get-npm-version
 
     - name: Get npm cache directory


### PR DESCRIPTION
fixes https://github.com/graycoreio/daffodil/actions/runs/26543349095/job/78189721589?pr=4452:
```
Run npx npm -g i npm@11
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/share/man/man7
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man7'
npm error     at async mkdir (node:internal/fs/promises:858:10)
npm error     at async Promise.all (index 0)
npm error     at async Promise.all (index 1)
npm error     at async #createBinLinks (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:402:5)
npm error     at async Promise.allSettled (index 0)
npm error     at async #linkAllBins (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:376:5)
npm error     at async #build (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:161:7)
npm error     at async Arborist.rebuild (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:63:5)
npm error     at async [reifyPackages] (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:334:11)
npm error     at async Arborist.reify (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:149:5) {
npm error   errno: -13,
npm error   code: 'EACCES',
npm error   syscall: 'mkdir',
npm error   path: '/usr/local/share/man/man7'
npm error }
```

Another potential fix is to use a version manager to install node but that seems less desirable for CI: https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally